### PR TITLE
Fix README rate limit anchor and lint scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
   - [Files Posting](#files-posting)
   - [HTML Form Posting](#-html-form-posting-browser)
   - [🆕 Progress capturing](#-progress-capturing)
-  - [🆕 Rate limiting](#-progress-capturing)
+  - [🆕 Rate limiting](#-rate-limiting)
   - [🆕 AxiosHeaders](#-axiosheaders)
   - [🔥 Fetch adapter](#-fetch-adapter)
   - [Semver](#semver)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "npm run test:eslint && npm run test:mocha && npm run test:karma && npm run test:dtslint && npm run test:exports",
-    "test:eslint": "node bin/ssl_hotfix.js eslint lib/**/*.js",
+    "test:eslint": "node bin/ssl_hotfix.js eslint -c .eslintrc.cjs lib/**/*.js",
     "test:dtslint": "dtslint --localTs node_modules/typescript/lib",
     "test:mocha": "node bin/ssl_hotfix.js mocha test/unit/**/*.js --timeout 30000 --exit",
     "test:exports": "node bin/ssl_hotfix.js mocha test/module/test.js --timeout 30000 --exit",
@@ -55,7 +55,8 @@
     "build": "gulp clear && cross-env NODE_ENV=production rollup -c -m",
     "examples": "node ./examples/server.js",
     "coveralls": "cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "fix": "eslint --fix lib/**/*.js",
+    "fix": "eslint -c .eslintrc.cjs --fix lib/**/*.js",
+    "lint": "eslint -c .eslintrc.cjs lib/**/*.js",
     "prepare": "husky install && npm run prepare:hooks",
     "prepare:hooks": "npx husky set .husky/commit-msg \"npx commitlint --edit $1\"",
     "release:dry": "release-it --dry-run --no-npm",


### PR DESCRIPTION
## Summary
- fix incorrect README anchor for rate limiting
- add `lint` script alias
- point ESLint scripts at `.eslintrc.cjs`

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm run lint` *(fails: ESLint config incompatible)*

------
https://chatgpt.com/codex/tasks/task_e_6850ba1c42a483299dec20b1780faac1